### PR TITLE
remove defaults channel

### DIFF
--- a/environments/environment.yml
+++ b/environments/environment.yml
@@ -2,7 +2,6 @@ name: routine-nanopore-qc
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - python=3
   - nanoq=0.10.0


### PR DESCRIPTION
Just the standard adjustment to remove defaults from the `environment.yml` to allow a new install.

I have test this on a set of samples from a minion run, it worked without problem.